### PR TITLE
added configuration to skip saving pinned tabs

### DIFF
--- a/SessionBuddy Extension/SafariExtensionHandler.swift
+++ b/SessionBuddy Extension/SafariExtensionHandler.swift
@@ -19,7 +19,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
         // your extension calls safari.extension.dispatchMessage("message").
         if messageName == "DOMContentLoaded" || messageName == "BeforeUnload" {
             DispatchQueue.global(qos: .userInitiated).async {
-                self.saveLatestSession()
+                self.saveLatestSession();
             }
         }
     }
@@ -33,27 +33,32 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
         SFSafariApplication.getActiveWindow { window in
             window?.getAllTabs { tabs in
                 var sessionTabs = [Tab]()
-                
                 for (index, tab) in tabs.enumerated() {
-                    tab.getActivePage { page in
-                        page?.getPropertiesWithCompletionHandler { properties in
-                            if let url = properties?.url?.absoluteString,
-                                let title = properties?.title {
-                                sessionTabs.append(Tab(title: title, url: url))
-                            }
-                            
-                            // Last element
-                            if index == tabs.count - 1 {
-                                var newSession = Session(
-                                    title: "Latest Session",
-                                    tabs: sessionTabs)
-                                
-                                newSession.isBackup = true
-                                LocalStorage.sessions = [newSession] + LocalStorage.sessions
-                                  NotificationCenter.default.post(Notification(name: Notification.Name("sessionDidChange")))
+                    tab.getContainingWindow(completionHandler: { win in
+                        let ignoreTab = Preferences.ignorePinnedTabs && win == nil;
+                        if !ignoreTab {
+                            tab.getActivePage { page in
+                                page?.getPropertiesWithCompletionHandler { properties in
+                                    if let url = properties?.url?.absoluteString,
+                                        let title = properties?.title {
+                                        sessionTabs.append(Tab(title: title, url: url))
+                                    }
+                                    
+                                    // Last element
+                                    if index == tabs.count - 1 {
+                                        var newSession = Session(
+                                            title: "Latest Session",
+                                            tabs: sessionTabs
+                                        )
+                                        
+                                        newSession.isBackup = true
+                                        LocalStorage.sessions = [newSession] + LocalStorage.sessions
+                                        NotificationCenter.default.post(Notification(name: Notification.Name("sessionDidChange")))
+                                    }
+                                }
                             }
                         }
-                    }
+                    })
                 }
             }
         }

--- a/SessionBuddy Extension/SafariExtensionHandler.swift
+++ b/SessionBuddy Extension/SafariExtensionHandler.swift
@@ -19,7 +19,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
         // your extension calls safari.extension.dispatchMessage("message").
         if messageName == "DOMContentLoaded" || messageName == "BeforeUnload" {
             DispatchQueue.global(qos: .userInitiated).async {
-                self.saveLatestSession();
+                self.saveLatestSession()
             }
         }
     }
@@ -33,9 +33,10 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
         SFSafariApplication.getActiveWindow { window in
             window?.getAllTabs { tabs in
                 var sessionTabs = [Tab]()
+                
                 for (index, tab) in tabs.enumerated() {
                     tab.getContainingWindow(completionHandler: { win in
-                        let ignoreTab = Preferences.ignorePinnedTabs && win == nil;
+                        let ignoreTab = Preferences.ignorePinnedTabs && win == nil
                         if !ignoreTab {
                             tab.getActivePage { page in
                                 page?.getPropertiesWithCompletionHandler { properties in

--- a/SessionBuddy Extension/Views/Preferences/PreferencesViewConttroller.swift
+++ b/SessionBuddy Extension/Views/Preferences/PreferencesViewConttroller.swift
@@ -11,38 +11,46 @@ import Cocoa
 class PreferencesViewConttroller: NSViewController {
 
     @IBOutlet weak var checkboxShowLatestSession: NSButton!
-    
+    @IBOutlet weak var checkboxIgnorePinnedTabs: NSButton!
+
     var onNavigationBack: ((Bool) -> Void)?
-    
+
     private var shouldUpdate = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
     }
-    
+
     func set(onNavigationBack: @escaping ((Bool) -> Void)) {
         self.onNavigationBack = onNavigationBack
     }
-    
+
     private func setupViews() {
         checkboxShowLatestSession.state = Preferences.showLatestSession ? .on : .off
+        checkboxIgnorePinnedTabs.state = Preferences.ignorePinnedTabs ? .on : .off
     }
-    
+
     @IBAction func toggleShowTheLatestSession(_ sender: Any) {
         Preferences.showLatestSession = checkboxShowLatestSession.state == .on
         if checkboxShowLatestSession.state == .on {
             LocalStorage.sessions.removeAll(where: (\.isBackup))
             NotificationCenter.default.post(Notification(name: Notification.Name("sessionDidChange")))
         }
-        
+
         shouldUpdate = true
     }
-    
+
+    @IBAction func toggleIgnorePinnedTabs(_ sender: Any) {
+        Preferences.ignorePinnedTabs = checkboxIgnorePinnedTabs.state == .on
+
+        shouldUpdate = true
+    }
+
     @IBAction func backToPrevious(_ sender: Any) {
         self.onNavigationBack?(shouldUpdate)
         self.view.removeFromSuperview()
         self.removeFromParent()
     }
-    
+
 }

--- a/SessionBuddy Extension/Views/Preferences/PreferencesViewConttroller.swift
+++ b/SessionBuddy Extension/Views/Preferences/PreferencesViewConttroller.swift
@@ -12,35 +12,35 @@ class PreferencesViewConttroller: NSViewController {
 
     @IBOutlet weak var checkboxShowLatestSession: NSButton!
     @IBOutlet weak var checkboxIgnorePinnedTabs: NSButton!
-
+    
     var onNavigationBack: ((Bool) -> Void)?
-
+    
     private var shouldUpdate = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
     }
-
+    
     func set(onNavigationBack: @escaping ((Bool) -> Void)) {
         self.onNavigationBack = onNavigationBack
     }
-
+    
     private func setupViews() {
         checkboxShowLatestSession.state = Preferences.showLatestSession ? .on : .off
         checkboxIgnorePinnedTabs.state = Preferences.ignorePinnedTabs ? .on : .off
     }
-
+    
     @IBAction func toggleShowTheLatestSession(_ sender: Any) {
         Preferences.showLatestSession = checkboxShowLatestSession.state == .on
         if checkboxShowLatestSession.state == .on {
             LocalStorage.sessions.removeAll(where: (\.isBackup))
             NotificationCenter.default.post(Notification(name: Notification.Name("sessionDidChange")))
         }
-
+        
         shouldUpdate = true
     }
-
+    
     @IBAction func toggleIgnorePinnedTabs(_ sender: Any) {
         Preferences.ignorePinnedTabs = checkboxIgnorePinnedTabs.state == .on
 
@@ -52,5 +52,5 @@ class PreferencesViewConttroller: NSViewController {
         self.view.removeFromSuperview()
         self.removeFromParent()
     }
-
+    
 }

--- a/SessionBuddy Extension/Views/Preferences/PreferencesViewConttroller.xib
+++ b/SessionBuddy Extension/Views/Preferences/PreferencesViewConttroller.xib
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesViewConttroller" customModule="Session_Buddy_Extension" customModuleProvider="target">
             <connections>
+                <outlet property="checkboxIgnorePinnedTabs" destination="2tL-ZM-f9J" id="wQh-cu-wbS"/>
                 <outlet property="checkboxShowLatestSession" destination="o2i-AP-byM" id="led-PB-wBI"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
@@ -51,6 +52,17 @@
                     <connections>
                         <action selector="backToPrevious:" target="-2" id="bV2-g2-deM"/>
                     </connections>
+                </button>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2tL-ZM-f9J">
+                    <rect key="frame" x="6" y="11" width="136" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Ignore pinned tabs" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="okC-t9-0Bw">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                        <connections>
+                            <action selector="toggleIgnorePinnedTabs:" target="-2" id="VBP-xc-pvu"/>
+                        </connections>
+                    </buttonCell>
                 </button>
             </subviews>
             <constraints>

--- a/SessionBuddy Extension/Views/SessionListView/SafariExtensionViewController.swift
+++ b/SessionBuddy Extension/Views/SessionListView/SafariExtensionViewController.swift
@@ -160,7 +160,7 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
                 
                 for (index, tab) in tabs.enumerated() {
                     tab.getContainingWindow(completionHandler: { win in
-                        let ignoreTab = Preferences.ignorePinnedTabs && win == nil;
+                        let ignoreTab = Preferences.ignorePinnedTabs && win == nil
                         if !ignoreTab {
                             tab.getActivePage { page in
                                 page?.getPropertiesWithCompletionHandler { properties in

--- a/SessionBuddy Extension/Views/SessionListView/SafariExtensionViewController.swift
+++ b/SessionBuddy Extension/Views/SessionListView/SafariExtensionViewController.swift
@@ -159,34 +159,39 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
                 var sessionTabs = [Tab]()
                 
                 for (index, tab) in tabs.enumerated() {
-                    tab.getActivePage { page in
-                        page?.getPropertiesWithCompletionHandler { properties in
-                            if let url = properties?.url?.absoluteString,
-                                let title = properties?.title {
-                                sessionTabs.append(Tab(title: title, url: url))
-                            }
-                            
-                            // Last element
-                            if index == tabs.count - 1 {
-                                let title = Date().commonStringFormat()
-                                
-                                let newSession = Session(
-                                    title: title,
-                                    tabs: sessionTabs)
-                                
-                                newSession.save()
-                                DispatchQueue.main.async {
-                                    self.outlineView.insertItems(
-                                        at: .init(integer: LocalStorage.sessions.count - 1),
-                                        inParent: nil,
-                                        withAnimation: .effectFade)
+                    tab.getContainingWindow(completionHandler: { win in
+                        let ignoreTab = Preferences.ignorePinnedTabs && win == nil;
+                        if !ignoreTab {
+                            tab.getActivePage { page in
+                                page?.getPropertiesWithCompletionHandler { properties in
+                                    if let url = properties?.url?.absoluteString,
+                                        let title = properties?.title {
+                                        sessionTabs.append(Tab(title: title, url: url))
+                                    }
                                     
-                                    self.outlineView.scrollToEndOfDocument(self)
+                                    // Last element
+                                    if index == tabs.count - 1 {
+                                        let title = Date().commonStringFormat()
+                                        
+                                        let newSession = Session(
+                                            title: title,
+                                            tabs: sessionTabs)
+                                        
+                                        newSession.save()
+                                        DispatchQueue.main.async {
+                                            self.outlineView.insertItems(
+                                                at: .init(integer: LocalStorage.sessions.count - 1),
+                                                inParent: nil,
+                                                withAnimation: .effectFade)
+                                            
+                                            self.outlineView.scrollToEndOfDocument(self)
+                                        }
+                                    }
+                                                          
                                 }
                             }
-                                                  
                         }
-                    }
+                    })
                 }
             }
         }

--- a/Share/Storage/LocalStorage.swift
+++ b/Share/Storage/LocalStorage.swift
@@ -12,6 +12,7 @@ extension UserDefaults {
     enum Key {
         static let sessions = "sessions"
         static let showLatestSession = "showLatestSession"
+        static let ignorePinnedTabs = "ignorePinnedTabs"
     }
 }
 
@@ -46,6 +47,20 @@ enum Preferences {
             UserDefaults.standard.set(
                 newValue,
                 forKey: UserDefaults.Key.showLatestSession)
+        }
+    }
+
+    static var ignorePinnedTabs: Bool {
+        get {
+            UserDefaults
+                .standard
+                .bool(forKey: UserDefaults.Key.ignorePinnedTabs)
+        }
+        
+        set {
+            UserDefaults.standard.set(
+                newValue,
+                forKey: UserDefaults.Key.ignorePinnedTabs)
         }
     }
 }


### PR DESCRIPTION
#### What's this PR do?

This PR adds a new preference setting "Ignore pinned tabs".

When activated: pinned tabs will not be added to the list of URLs when saving a session.

The main logic that was added (besides the new preference) is the following if:
```swift
                    tab.getContainingWindow(completionHandler: { win in
                        let ignoreTab = Preferences.ignorePinnedTabs && win == nil;
                        if !ignoreTab {
                           // normal saving logic
                        }
                    });
```

Discussion on how to detect pinned tabs:
- https://developer.apple.com/forums/thread/123120
- https://stackoverflow.com/questions/63509871/check-if-tab-page-is-pinned-in-safari-app-extension

Here is a screenshot of the relevant method in `SFSafariTab` class:
<img width="658" alt="Bildschirmfoto 2020-09-26 um 15 44 26" src="https://user-images.githubusercontent.com/533162/94342131-2af2d980-000f-11eb-98f8-97f0b6c46dd6.png">

This is my first take on a Swift project (normally PHP is my dev language) so please review with care. I am especially unsure about the `.xib` file which I didn't edit manually. And sorry for the unrelated white space changes, I opened the file with another IDE and didn't recognize them before seeing the diff here at GH...

#### What are the relevant Git tickets?

Fixes https://github.com/dwarvesf/session-buddy/issues/10

#### Screenshots (if appropriate)

<img width="343" alt="Bildschirmfoto 2020-09-26 um 15 46 53" src="https://user-images.githubusercontent.com/533162/94342171-82914500-000f-11eb-836b-8f0dc8899a41.png">
